### PR TITLE
Remove dead array assignment that breaks .githelpers under dash

### DIFF
--- a/.githelpers
+++ b/.githelpers
@@ -225,7 +225,6 @@ list_branches_by_relative_commit() {
 
 # Interactively switch to a recent branch using a selection menu with j/k or arrow keys, and Enter to confirm.
 switch_recent_branches_by_index() {
-  local branches=($(list_branches_by_relative_commit | awk '{print $NF}'))
   local current_branch=$(git branch --show-current)
 
   # Use fzf for interactive selection


### PR DESCRIPTION
## What

Delete one dead line from `switch_recent_branches_by_index` in `.githelpers`:

```diff
 switch_recent_branches_by_index() {
-  local branches=($(list_branches_by_relative_commit | awk '{print $NF}'))
   local current_branch=$(git branch --show-current)
```

`branches` is assigned and then never read — the function pipes `list_branches_by_relative_commit` straight into `fzf` a few lines down. It's leftover from a pre-fzf implementation.

## Why it matters

Git runs `!`-prefixed aliases through `/bin/sh`. On Debian/Ubuntu (and the exe.dev VMs), `/bin/sh` is `dash`. When an alias like `git l` does `!. ~/.githelpers && pretty_git_log`, dash **sources** the file — and dash parses the *entire* file before executing anything. The bash array literal `name=(...)` is the one bit of syntax dash can't parse, so it aborts:

```
$ git l
.githelpers: 228: Syntax error: "(" unexpected (expecting "}")
```

That isn't isolated to the fzf switcher — it takes down **every** alias that sources this file (`l`, `b`, `bs`, `lb`, `opb`, `pb`, …), since none of them get past the parse. Removing the dead line fixes all of them.

The `[[ ]]` uses elsewhere in the file parse fine under dash (they only fail at runtime, inside their own functions) — this array literal was the sole *parse*-level bashism.

## Verification

```
dash -n .githelpers            # parses clean
sh -c '. ./.githelpers'        # sources OK (was: Syntax error)
bash -c '. ./.githelpers && type switch_recent_branches_by_index'   # fn still defined
```

No behavior change on systems where `/bin/sh` is bash — the line was dead there too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)