### PR TITLE
Add prudence.md: model and effort selection heuristics

### DIFF
--- a/.claude/rules/prudence.md
+++ b/.claude/rules/prudence.md
@@ -1,0 +1,24 @@
+## Model and Effort Selection
+
+Use this when picking a model and reasoning effort for a task — your own or a delegated subagent's. These are defaults, not laws: the human overrides, and evidence of struggle beats a guess.
+
+### Match the model to the work
+
+- **Brainstorming, ideation, divergent drafting** — Fable, medium. Breadth matters more than depth here; save the heavy tiers for when a decision is on the line.
+- **Planning, triage, architecture, hard root-cause debugging** — Opus, xhigh (max for the gnarliest calls). Choices that are expensive to reverse — or that many later steps lean on — earn the deepest reasoning.
+- **Implementation, refactors, delegated research, code review** — Sonnet. The workhorse. Scale effort to risk: mechanical edits run low, integration work runs high.
+- **Commit messages, PR summaries, short prose, mechanical transcription** — Haiku, low. Fast and cheap for low-stakes text where the answer is already known.
+
+### Principles
+
+- **Least powerful model that can do the job.** Start low, escalate on evidence — a subagent that stalls, a review that keeps missing things — not on a hunch that a task "feels hard".
+- **Turn count beats token price.** A cheap model that flails for ten turns costs more than a capable one that lands in three. When the plan already spells out the steps, the cheapest tier fits; when it doesn't, floor at Sonnet.
+- **Effort tracks stakes, not size.** A one-line change to auth logic is high effort; a hundred-line mechanical rename is low. Ask what breaks if you're wrong.
+- **Give the last word to Opus.** Whatever tier did the work, the final adversarial review — the one gating a merge — runs on Opus at high effort or above.
+- **Name the model when you delegate.** An omitted model inherits the session's, often the most expensive — set it explicitly on every subagent.
+
+### Before dispatching
+
+1. What is this — generate, decide, build or transcribe?
+2. Pick the model from the list above; set effort by stakes, not line count.
+3. Delegating? State model and effort explicitly in the dispatch.


### PR DESCRIPTION
A new auto-loaded rule documenting *when* to reach for which model tier and reasoning effort — Fable/medium for brainstorming, Opus/xhigh for planning & triage, Sonnet for implementation & delegated research, Haiku/low for commit messages & short prose — plus a few governing principles (least-powerful-that-works, turn-count-beats-token-price, Opus for the final gating review, name the model when delegating).

## Wiring

None needed. Files under `.claude/rules/` are auto-discovered and loaded at launch (same priority as `CLAUDE.md`) — `/memory` lists them. So this is one file, no `CLAUDE.md` change. (The old `@rules/…` imports stay gone; re-adding them would double-load.)

## Style

Matches the sibling rules: no frontmatter, `##` heading + scope line, bold-lead-in bullets, no tables, em-dashes for asides, and it obeys the repo's own language rules (no Oxford comma, no "just"/"simply").

## Verify

Open a fresh session (or `/memory`) and confirm `.claude/rules/prudence.md` appears among the loaded rules.